### PR TITLE
Only use CONDA_DEPENDENCIES for ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,9 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install'
         - PIP_INSTALL='pip install'
-        - CONDA_ADDITIONAL_DEPENDENCIES='Cython'
-        - PIP_ADDITIONAL_DEPENDENCIES='pytest-xdist'
-        - CONDA_OPTIONAL_DEPENDENCIES='scipy scikit-image matplotlib'
-        - PIP_OPTIONAL_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='Cython'
+        - PIP_DEPENDENCIES='pytest-xdist'
+        - CONDA_OPTIONAL='scipy scikit-image matplotlib'
 
     matrix:
         - SETUP_CMD='egg_info'
@@ -67,9 +66,9 @@ matrix:
 
         # Try with optional dependencies disabled
         - python: 2.7
-          env: SETUP_CMD='test' CONDA_DEPENDENCIES=$CONDA_ADDITIONAL_DEPENDENCIES
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES+=$CONDA_OPTIONAL
         - python: 3.4
-          env: SETUP_CMD='test' CONDA_DEPENDENCIES=$CONDA_ADDITIONAL_DEPENDENCIES
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES+=$CONDA_OPTIONAL
 
         # Try older numpy versions
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ python:
     - 2.7
     - 3.3
     - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -25,13 +24,16 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install'
-        - PIP_INSTALL='pip install'
         - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - PIP_DEPENDENCIES='pytest-xdist'
 
     matrix:
+
+        # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info' CONDA_DEPENDENCIES=''
+
+        # Try all python versions with the latest numpy
+        - SETUP_CMD='test'
 
 matrix:
     include:
@@ -52,16 +54,6 @@ matrix:
         # Try Astropy development version
         - python: 3.3
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-
-        # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
-        - python: 3.4
-          env: SETUP_CMD='test'
 
         # Try with optional dependencies disabled
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
 
         # Try with optional dependencies disabled
         - python: 2.7
-          env: SETUP_CMD='test' CONDA_DEPENDENCIES+=$CONDA_OPTIONAL
+          env: SETUP_CMD='test' CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.4
           env: SETUP_CMD='test' CONDA_DEPENDENCIES+=$CONDA_OPTIONAL
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython'
-
         - python: 3.4
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,11 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install'
         - PIP_INSTALL='pip install'
-        - CONDA_DEPENDENCIES='Cython'
+        - CONDA_DEPENDENCIES='Cython scipy scikit-image matplotlib'
         - PIP_DEPENDENCIES='pytest-xdist'
-        - CONDA_OPTIONAL='scipy scikit-image matplotlib'
 
     matrix:
-        - SETUP_CMD='egg_info'
+        - SETUP_CMD='egg_info' CONDA_DEPENDENCIES=''
 
 matrix:
     include:
@@ -42,51 +41,44 @@ matrix:
         # coverage testing in affiliated packages.
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.4
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Try Astropy development version
         - python: 3.3
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Try all python versions with the latest numpy
         - python: 2.6
           env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.3
-          env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
-        - python: 3.4
-          env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
-        # Try with optional dependencies disabled
-        - python: 2.7
           env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
 
+        # Try with optional dependencies disabled
+        - python: 2.7
+          env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES='Cython'
+
+        - python: 3.4
+          env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES='Cython'
+
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,6 @@ before_install:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
 
-install:
-
-    # CORE DEPENDENCIES
-
-    # OPTIONAL_DEPENDENCIES
-
 script:
    - python setup.py $SETUP_CMD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,41 +42,51 @@ matrix:
         # coverage testing in affiliated packages.
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test --coverage'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.4
           env: ASTROPY_VERSION=development SETUP_CMD='build_sphinx -w'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Try Astropy development version
         - python: 3.3
           env: ASTROPY_VERSION=development SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
         # Try all python versions with the latest numpy
         - python: 2.6
           env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.3
           env: SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 3.4
           env: SETUP_CMD='test'
-
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         # Try with optional dependencies disabled
         - python: 2.7
-          env: SETUP_CMD='test' CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
+          env: SETUP_CMD='test'
         - python: 3.4
-          env: SETUP_CMD='test' CONDA_DEPENDENCIES+=$CONDA_OPTIONAL
+          env: SETUP_CMD='test'
 
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+               CONDA_DEPENDENCIES="$CONDA_DEPENDENCIES $CONDA_OPTIONAL"
 
 before_install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_ADDITIONAL_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
+      CONDA_DEPENDENCIES: "Cython scipy jinja2 scikit-image matplotlib"
 
   matrix:
       - PYTHON_VERSION: "2.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   global:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "3.5.5"
-      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.appveyor_windows_sdk.cmd"
+      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.


### PR DESCRIPTION
Not sure if this will work, but the idea would be that it's up to the user to construct the string of dependencies, and we only deal with one variable in `ci-helpers`
